### PR TITLE
Cleanup temporary template file

### DIFF
--- a/src/Gazorator/Gazorator.cs
+++ b/src/Gazorator/Gazorator.cs
@@ -60,14 +60,23 @@ namespace Gazorator
         public virtual async Task ProcessTemplateAsync(string template)
         {
             var tempFile = Path.GetTempFileName();
-
-            using (var stream = File.OpenWrite(tempFile))
-            using (var writer = new StreamWriter(stream))
+            try
             {
-                await writer.WriteAsync(template);
-            }
+                using (var stream = File.OpenWrite(tempFile))
+                using (var writer = new StreamWriter(stream))
+                {
+                    await writer.WriteAsync(template);
+                }
 
-            await ProcessAsync(tempFile);
+                await ProcessAsync(tempFile);
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
+            }
         }
 
         private sealed class DefaultGazorator : Gazorator


### PR DESCRIPTION
While passing template as a string the created temporary file should be removed after compilation.