### PR TITLE
(GH-14) Handle null refernce exception

### DIFF
--- a/src/Gazorator/Scripting/RazorContentGenerator.cs
+++ b/src/Gazorator/Scripting/RazorContentGenerator.cs
@@ -63,11 +63,15 @@ namespace Gazorator.Scripting
 
                 foreach (var reference in entryAssembly.GetReferencedAssemblies())
                 {
-                    yield return MetadataReference.CreateFromFile(Assembly.Load(reference).Location);
+                    var referencedAssembly = Assembly.Load(reference);
+                    if (referencedAssembly.Location != null)
+                    {
+                        yield return MetadataReference.CreateFromFile(referencedAssembly.Location);
+                    }
                 }
             }
 
-            foreach (var reference in _references)
+            foreach (var reference in _references.Where(r => r.Location != null))
             {
                 yield return MetadataReference.CreateFromFile(reference.Location);
             }


### PR DESCRIPTION
Found out that there were additional NRE's when testing using dotnet
test.  These hadn't shown when testing out of Visual Studio, but only
when testing from the command line.

Fixes #14 